### PR TITLE
Handle short reads

### DIFF
--- a/async_websocket_client/ws.py
+++ b/async_websocket_client/ws.py
@@ -74,11 +74,17 @@ class AsyncWebsocketClient:
         return line
 
     async def a_read(self, size: int = None):
-        b = None
-        while b is None:
+        chunks = []
+        while True:
             b = self.sock.read(size)
             await a.sleep_ms(self.delay_read)
-        return b
+            if b:
+                if (size is None or len(b) == size):
+                    return b
+                chunks.append(b)
+                size -= len(b)
+                if size == 0:
+                    return b''.join(chunks)
 
     async def handshake(self, uri, headers=[]):
         if self.sock:


### PR DESCRIPTION
Non-blocking socket though may return not as much data as requested (“short reads”). See https://docs.micropython.org/en/latest/library/socket.html#socket.socket.read.

When this happens, an incomplete websocket frame is returned and the protocol loses sync.

This fix continues reading for the remaining bytes and returns a complete websocket frame.